### PR TITLE
Add TV image denoising example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# convex-image-denoising
+# Convex Image Denoising
+
+This project demonstrates total variation (TV) based image denoising using
+convex optimization with [CVXPY](https://www.cvxpy.org/).
+
+The example loads the ``camera`` test image from ``scikit-image``, corrupts it
+with Gaussian noise and solves the optimization problem
+
+\[ \min_I \tfrac12 \|I - I_{\text{noisy}}\|_2^2 + \lambda\,\text{TV}(I) \]
+
+subject to \(0 \leq I \leq 1\). PSNR and SSIM are used to benchmark the
+results for different regularization weights.
+
+## Setup
+
+Install dependencies with pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run ``run.py`` to denoise an image and sweep across several ``lambda`` values:
+
+```bash
+python run.py
+```
+
+This displays the original, noisy and denoised images as well as a plot showing
+PSNR/SSIM over ``lambda``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+cvxpy
+scikit-image
+matplotlib
+numpy
+

--- a/run.py
+++ b/run.py
@@ -1,0 +1,53 @@
+"""Example script for TV image denoising."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from tv_denoise import (
+    add_gaussian_noise,
+    compute_metrics,
+    load_grayscale_image,
+    sweep_lambda,
+    tv_denoise,
+)
+
+
+def main() -> None:
+    image = load_grayscale_image()
+    noisy = add_gaussian_noise(image, sigma=0.1, seed=0)
+
+    lam = 0.1
+    denoised = tv_denoise(noisy, lam)
+    psnr, ssim = compute_metrics(image, denoised)
+    print(f"lambda={lam:.3f} PSNR={psnr:.2f} SSIM={ssim:.3f}")
+
+    # Visual comparison
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+    for ax, img, title in zip(
+        axes, [image, noisy, denoised], ["Original", "Noisy", f"Denoised (λ={lam})"]
+    ):
+        ax.imshow(img, cmap="gray", vmin=0, vmax=1)
+        ax.set_title(title)
+        ax.axis("off")
+    fig.tight_layout()
+    plt.show()
+
+    # Sweep over lambda values
+    lambdas = np.linspace(0.01, 0.2, 5)
+    results = sweep_lambda(noisy, image, lambdas.tolist())
+    for lam, p, s in results:
+        print(f"lambda={lam:.3f} PSNR={p:.2f} SSIM={s:.3f}")
+
+    plt.figure()
+    plt.plot(lambdas, [p for _, p, _ in results], label="PSNR")
+    plt.plot(lambdas, [s for _, _, s in results], label="SSIM")
+    plt.xlabel("lambda")
+    plt.legend()
+    plt.title("Performance vs Regularization")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tv_denoise.py
+++ b/tests/test_tv_denoise.py
@@ -1,0 +1,17 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tv_denoise import load_grayscale_image, add_gaussian_noise, tv_denoise, compute_metrics
+
+
+def test_tv_improves_psnr():
+    image = load_grayscale_image()
+    image = image[::4, ::4]
+    noisy = add_gaussian_noise(image, sigma=0.1, seed=0)
+
+    psnr_noisy, _ = compute_metrics(image, noisy)
+    denoised = tv_denoise(noisy, lam=0.1)
+    psnr_denoised, _ = compute_metrics(image, denoised)
+
+    assert psnr_denoised > psnr_noisy
+    assert denoised.shape == image.shape

--- a/tv_denoise.py
+++ b/tv_denoise.py
@@ -1,0 +1,53 @@
+"""Utilities for total variation image denoising using convex optimization."""
+
+from __future__ import annotations
+
+import numpy as np
+import cvxpy as cp
+from skimage import data, img_as_float
+from skimage.metrics import peak_signal_noise_ratio, structural_similarity
+
+
+def load_grayscale_image() -> np.ndarray:
+    """Load the standard camera test image as a float array in [0, 1]."""
+    image = img_as_float(data.camera())
+    return image
+
+
+def add_gaussian_noise(image: np.ndarray, sigma: float = 0.1, seed: int | None = None) -> np.ndarray:
+    """Return a noisy copy of ``image`` with additive Gaussian noise."""
+    rng = np.random.default_rng(seed)
+    noisy = image + rng.normal(scale=sigma, size=image.shape)
+    return np.clip(noisy, 0, 1)
+
+
+def tv_denoise(noisy: np.ndarray, lam: float, max_iter: int = 1000) -> np.ndarray:
+    """Solve a TV-denoising problem for ``noisy`` with regularization ``lam``."""
+    m, n = noisy.shape
+    u = cp.Variable((m, n))
+    obj = 0.5 * cp.sum_squares(u - noisy) + lam * cp.tv(u)
+    constraints = [u >= 0, u <= 1]
+    problem = cp.Problem(cp.Minimize(obj), constraints)
+    problem.solve(verbose=False, max_iter=max_iter)
+    return u.value
+
+
+def compute_metrics(clean: np.ndarray, denoised: np.ndarray) -> tuple[float, float]:
+    """Return PSNR and SSIM comparing ``clean`` and ``denoised``."""
+    psnr = peak_signal_noise_ratio(clean, denoised, data_range=1)
+    ssim = structural_similarity(clean, denoised, data_range=1)
+    return psnr, ssim
+
+
+def sweep_lambda(noisy: np.ndarray, clean: np.ndarray, lambdas: list[float]) -> list[tuple[float, float, float]]:
+    """Denoise ``noisy`` for each lambda and return metrics.
+
+    Returns a list of ``(lambda, psnr, ssim)`` tuples.
+    """
+    results = []
+    for lam in lambdas:
+        denoised = tv_denoise(noisy, lam)
+        psnr, ssim = compute_metrics(clean, denoised)
+        results.append((lam, psnr, ssim))
+    return results
+


### PR DESCRIPTION
## Summary
- add utilities for TV denoising with CVXPY
- provide example script and dependency list
- document setup and usage
- basic test verifying PSNR improvement

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7628abcc83229aa10e250c43a6ae